### PR TITLE
Fix not to use panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ TODO
 
 import (
 	"database/sql"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -22,11 +23,13 @@ func main() {
 
 	db, err := sql.Open("sqlite3", "database.db")
 	if err != nil {
-		panic(err)
+		log.Println("failed to open sqlite file")
+		os.Exit(1)
 	}
 
 	if err := initDB(db); err != nil {
-		panic(err)
+		log.Printf("failed to initialize db err: %#v", err)
+		os.Exit(1)
 	}
 
 	h := &handler{


### PR DESCRIPTION
## What
- `panic` を使わず `os.Exit(1)` でアプリケーションを終了させる