### PR TITLE
[UPDATE] split other handlers

### DIFF
--- a/handler/http_handler.go
+++ b/handler/http_handler.go
@@ -118,3 +118,89 @@ func (h *Handler) PurchaseHandler(w http.ResponseWriter, r *http.Request) {
 
 	http.Redirect(w, r, "/Purchase_page?id="+l.ID, http.StatusFound)
 }
+
+
+// handler for result
+func (h *Handler) ResultHandler(w http.ResponseWriter, r *http.Request) {
+    resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    defer resp1.Body.Close()
+
+    var result types.Result
+    if err := json.NewDecoder(resp1.Body).Decode(&result); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+
+    resp2, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    defer resp2.Body.Close()
+
+    var l types.Lottery
+    if err := json.NewDecoder(resp2.Body).Decode(&l); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+
+    type winner struct {
+        Prize   *types.Prize
+        Numbers []string
+    }
+
+    data := struct {
+        types.Lottery
+        Winners map[string]*winner
+    }{
+        Lottery: l,
+        Winners: map[string]*winner{},
+    }
+
+    rows, err := h.DB.Query("SELECT number FROM Purchased WHERE lottery_id = ?", l.ID)
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    for rows.Next() {
+        var number string
+        if err := rows.Scan(&number); err != nil {
+            const status = http.StatusInternalServerError
+            http.Error(w, http.StatusText(status), status)
+            return
+        }
+
+        for i := range result.Winners {
+            for _, n := range result.Winners[i].Numbers {
+                if number == n {
+                    prizeID := result.Winners[i].PrizeID
+                    if data.Winners[prizeID] == nil {
+                        for _, p := range l.Prizes {
+                            if p.ID == prizeID {
+                                data.Winners[prizeID] = &winner{
+                                    Prize: p,
+                                }
+                            }
+                        }
+                    }
+                    data.Winners[prizeID].Numbers = append(data.Winners[prizeID].Numbers, n)
+                }
+            }
+        }
+    }
+
+    if err := preview.ResultTmpl.Execute(w, data); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+}

--- a/handler/http_handler.go
+++ b/handler/http_handler.go
@@ -66,3 +66,48 @@ func (h *Handler) PurchasePageHandler(w http.ResponseWriter, r *http.Request) {
     }
 }
 
+func (h *Handler) PurchaseHandler(w http.ResponseWriter, r *http.Request) {
+    id := r.FormValue("id")
+    num, err := strconv.Atoi(r.FormValue("num"))
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    // TODO: パラメタのバリデーション
+
+    resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + id)
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    defer resp.Body.Close()
+
+    var l types.Lottery
+    if err := json.NewDecoder(resp.Body).Decode(&l); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+
+    var count int
+    if err := db.QueryRow("SELECT COUNT(*) FROM Purchased WHERE lottery_id = ?", l.ID).Scan(&count); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+
+    for i := 1; i <= num; i++ {
+        const sql = "INSERT INTO Purchased(lottery_id, number) values (?,?)"
+        format := fmt.Sprintf(`%%0%dd`, len(strconv.FormatInt(l.Num-1, 10)))
+        n := fmt.Sprintf(format, count+i)
+        if _, err := db.Exec(sql, id, n); err != nil {
+            const status = http.StatusInternalServerError
+            http.Error(w, http.StatusText(status), status)
+            return
+        }
+    }
+
+    http.Redirect(w, r, "/Purchase_page?id="+l.ID, http.StatusFound)
+}

--- a/handler/http_handler.go
+++ b/handler/http_handler.go
@@ -17,7 +17,7 @@ type Handler struct {
 	DB *sql.DB
 }
 
-// handler for home page
+// HomeHandler provides a handler for Home
 func (h *Handler) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/available_lotteries")
 	if err != nil {
@@ -41,7 +41,7 @@ func (h *Handler) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handler for purchase page
+// PurchasePageHandler provides a handler for PurchasePage
 func (h *Handler) PurchasePageHandler(w http.ResponseWriter, r *http.Request) {
 	resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
 	if err != nil {
@@ -72,7 +72,7 @@ func (h *Handler) PurchasePageHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handler for parchase
+// PurchaseHandler provides a handler for purchasing
 func (h *Handler) PurchaseHandler(w http.ResponseWriter, r *http.Request) {
 	id := r.FormValue("id")
 	num, err := strconv.Atoi(r.FormValue("num"))
@@ -119,7 +119,7 @@ func (h *Handler) PurchaseHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/Purchase_page?id="+l.ID, http.StatusFound)
 }
 
-// handler for result
+// ResultHandler provides a handler for getting result
 func (h *Handler) ResultHandler(w http.ResponseWriter, r *http.Request) {
 	resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))
 	if err != nil {

--- a/handler/http_handler.go
+++ b/handler/http_handler.go
@@ -34,3 +34,35 @@ func (h *Handler) HomeHandler(w http.ResponseWriter, r *http.Request) {
         return
     }
 }
+
+
+func (h *Handler) PurchasePageHandler(w http.ResponseWriter, r *http.Request) {
+    resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
+    if err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+    defer resp.Body.Close()
+
+    var l types.Lottery
+    if err := json.NewDecoder(resp.Body).Decode(&l); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+
+    data := struct {
+        types.Lottery
+        Remain int64
+    }{
+        Lottery: l,
+        Remain:  l.Num, // TODO: 残りを計算する
+    }
+    if err := preview.PurchasePageTmpl.Execute(w, data); err != nil {
+        const status = http.StatusInternalServerError
+        http.Error(w, http.StatusText(status), status)
+        return
+    }
+}
+

--- a/handler/http_handler.go
+++ b/handler/http_handler.go
@@ -119,88 +119,87 @@ func (h *Handler) PurchaseHandler(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/Purchase_page?id="+l.ID, http.StatusFound)
 }
 
-
 // handler for result
 func (h *Handler) ResultHandler(w http.ResponseWriter, r *http.Request) {
-    resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))
-    if err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
-    defer resp1.Body.Close()
+	resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))
+	if err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
+	defer resp1.Body.Close()
 
-    var result types.Result
-    if err := json.NewDecoder(resp1.Body).Decode(&result); err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
+	var result types.Result
+	if err := json.NewDecoder(resp1.Body).Decode(&result); err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
 
-    resp2, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
-    if err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
-    defer resp2.Body.Close()
+	resp2, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
+	if err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
+	defer resp2.Body.Close()
 
-    var l types.Lottery
-    if err := json.NewDecoder(resp2.Body).Decode(&l); err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
+	var l types.Lottery
+	if err := json.NewDecoder(resp2.Body).Decode(&l); err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
 
-    type winner struct {
-        Prize   *types.Prize
-        Numbers []string
-    }
+	type winner struct {
+		Prize   *types.Prize
+		Numbers []string
+	}
 
-    data := struct {
-        types.Lottery
-        Winners map[string]*winner
-    }{
-        Lottery: l,
-        Winners: map[string]*winner{},
-    }
+	data := struct {
+		types.Lottery
+		Winners map[string]*winner
+	}{
+		Lottery: l,
+		Winners: map[string]*winner{},
+	}
 
-    rows, err := h.DB.Query("SELECT number FROM Purchased WHERE lottery_id = ?", l.ID)
-    if err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
-    for rows.Next() {
-        var number string
-        if err := rows.Scan(&number); err != nil {
-            const status = http.StatusInternalServerError
-            http.Error(w, http.StatusText(status), status)
-            return
-        }
+	rows, err := h.DB.Query("SELECT number FROM Purchased WHERE lottery_id = ?", l.ID)
+	if err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
+	for rows.Next() {
+		var number string
+		if err := rows.Scan(&number); err != nil {
+			const status = http.StatusInternalServerError
+			http.Error(w, http.StatusText(status), status)
+			return
+		}
 
-        for i := range result.Winners {
-            for _, n := range result.Winners[i].Numbers {
-                if number == n {
-                    prizeID := result.Winners[i].PrizeID
-                    if data.Winners[prizeID] == nil {
-                        for _, p := range l.Prizes {
-                            if p.ID == prizeID {
-                                data.Winners[prizeID] = &winner{
-                                    Prize: p,
-                                }
-                            }
-                        }
-                    }
-                    data.Winners[prizeID].Numbers = append(data.Winners[prizeID].Numbers, n)
-                }
-            }
-        }
-    }
+		for i := range result.Winners {
+			for _, n := range result.Winners[i].Numbers {
+				if number == n {
+					prizeID := result.Winners[i].PrizeID
+					if data.Winners[prizeID] == nil {
+						for _, p := range l.Prizes {
+							if p.ID == prizeID {
+								data.Winners[prizeID] = &winner{
+									Prize: p,
+								}
+							}
+						}
+					}
+					data.Winners[prizeID].Numbers = append(data.Winners[prizeID].Numbers, n)
+				}
+			}
+		}
+	}
 
-    if err := preview.ResultTmpl.Execute(w, data); err != nil {
-        const status = http.StatusInternalServerError
-        http.Error(w, http.StatusText(status), status)
-        return
-    }
+	if err := preview.ResultTmpl.Execute(w, data); err != nil {
+		const status = http.StatusInternalServerError
+		http.Error(w, http.StatusText(status), status)
+		return
+	}
 }

--- a/main.go
+++ b/main.go
@@ -39,35 +39,7 @@ func main() {
     v := &handler.Handler{}
 	http.HandleFunc("/", v.HomeHandler)
 
-	http.HandleFunc("/Purchase_page", func(w http.ResponseWriter, r *http.Request) {
-		resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		defer resp.Body.Close()
-
-		var l types.Lottery
-		if err := json.NewDecoder(resp.Body).Decode(&l); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-
-		data := struct {
-			types.Lottery
-			Remain int64
-		}{
-			Lottery: l,
-			Remain:  l.Num, // TODO: 残りを計算する
-		}
-		if err := preview.PurchasePageTmpl.Execute(w, data); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-	})
+	http.HandleFunc("/Purchase_page", v.PurchasePageHandler)
 
 	http.HandleFunc("/Purchase", func(w http.ResponseWriter, r *http.Request) {
 		id := r.FormValue("id")

--- a/main.go
+++ b/main.go
@@ -41,51 +41,7 @@ func main() {
 
 	http.HandleFunc("/Purchase_page", v.PurchasePageHandler)
 
-	http.HandleFunc("/Purchase", func(w http.ResponseWriter, r *http.Request) {
-		id := r.FormValue("id")
-		num, err := strconv.Atoi(r.FormValue("num"))
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		// TODO: パラメタのバリデーション
-
-		resp, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + id)
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		defer resp.Body.Close()
-
-		var l types.Lottery
-		if err := json.NewDecoder(resp.Body).Decode(&l); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-
-		var count int
-		if err := db.QueryRow("SELECT COUNT(*) FROM Purchased WHERE lottery_id = ?", l.ID).Scan(&count); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-
-		for i := 1; i <= num; i++ {
-			const sql = "INSERT INTO Purchased(lottery_id, number) values (?,?)"
-			format := fmt.Sprintf(`%%0%dd`, len(strconv.FormatInt(l.Num-1, 10)))
-			n := fmt.Sprintf(format, count+i)
-			if _, err := db.Exec(sql, id, n); err != nil {
-				const status = http.StatusInternalServerError
-				http.Error(w, http.StatusText(status), status)
-				return
-			}
-		}
-
-		http.Redirect(w, r, "/Purchase_page?id="+l.ID, http.StatusFound)
-	})
+	http.HandleFunc("/Purchase", v.PurchaseHandler)
 
 	http.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
 		resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))

--- a/main.go
+++ b/main.go
@@ -11,14 +11,11 @@ TODO
 
 import (
 	"database/sql"
-	"encoding/json"
 	"net"
 	"net/http"
 	"os"
 
 	"github.com/stepupgo/stepupgo2-1/handler"
-	"github.com/stepupgo/stepupgo2-1/preview"
-	"github.com/stepupgo/stepupgo2-1/types"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -41,89 +38,7 @@ func main() {
 
 	http.HandleFunc("/purchase", v.PurchaseHandler)
 
-	http.HandleFunc("/result", func(w http.ResponseWriter, r *http.Request) {
-		resp1, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/result?id=" + r.FormValue("id"))
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		defer resp1.Body.Close()
-
-		var result types.Result
-		if err := json.NewDecoder(resp1.Body).Decode(&result); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-
-		resp2, err := http.Get("https://lottery-dot-tenntenn-samples.appspot.com/lottery?id=" + r.FormValue("id"))
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		defer resp2.Body.Close()
-
-		var l types.Lottery
-		if err := json.NewDecoder(resp2.Body).Decode(&l); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-
-		type winner struct {
-			Prize   *types.Prize
-			Numbers []string
-		}
-
-		data := struct {
-			types.Lottery
-			Winners map[string]*winner
-		}{
-			Lottery: l,
-			Winners: map[string]*winner{},
-		}
-
-		rows, err := db.Query("SELECT number FROM Purchased WHERE lottery_id = ?", l.ID)
-		if err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-		for rows.Next() {
-			var number string
-			if err := rows.Scan(&number); err != nil {
-				const status = http.StatusInternalServerError
-				http.Error(w, http.StatusText(status), status)
-				return
-			}
-
-			for i := range result.Winners {
-				for _, n := range result.Winners[i].Numbers {
-					if number == n {
-						prizeID := result.Winners[i].PrizeID
-						if data.Winners[prizeID] == nil {
-							for _, p := range l.Prizes {
-								if p.ID == prizeID {
-									data.Winners[prizeID] = &winner{
-										Prize: p,
-									}
-								}
-							}
-						}
-						data.Winners[prizeID].Numbers = append(data.Winners[prizeID].Numbers, n)
-					}
-				}
-			}
-		}
-
-		if err := preview.ResultTmpl.Execute(w, data); err != nil {
-			const status = http.StatusInternalServerError
-			http.Error(w, http.StatusText(status), status)
-			return
-		}
-	})
+	http.HandleFunc("/result", v.ResultHandler)
 
 	port := os.Getenv("PORT")
 	if port == "" {


### PR DESCRIPTION
 - `main.go`のpurchase_page, purchase, resultの3つのハンドラを関数化
 - dbをhandler構造体に内包化